### PR TITLE
(Closes #23) Update config and ServiceProvider

### DIFF
--- a/src/REINetwork/BriteVerify/BriteVerifyServiceProvider.php
+++ b/src/REINetwork/BriteVerify/BriteVerifyServiceProvider.php
@@ -20,8 +20,13 @@ class BriteVerifyServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // Removing this line for now. Until we can verify we still need it.
-//        $this->package('reinetwork/briteverify');
+        $configPath = __DIR__ . '/../../config/briteverify.php';
+        if (function_exists('config_path')) {
+            $publishPath = config_path('briteverify.php');
+        } else {
+            $publishPath = base_path('config/briteverify.php');
+        }
+        $this->publishes([$configPath => $publishPath], 'config');
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
 
     /*
     |--------------------------------------------------------------------------
@@ -13,4 +13,17 @@ return array(
 
     'token' => null,
 
-);
+
+    /*
+    |--------------------------------------------------------------------------
+    | BriteVerify Pretend flag
+    |--------------------------------------------------------------------------
+    |
+    | When in local or testing, this flag will be true. Otherwise, for staging, and prod,
+    | it will be false.
+    |
+    */
+
+    'pretend' => env('APP_ENV') == 'local' || env('APP_ENV') == 'testing' ? true : false,
+
+];


### PR DESCRIPTION
Added the `pretend` flag to the configuration and set it for true only in local and testing environemnts.

Added publishing functionality to the boot function in the ServiceProvider to push the configuration to the
  config folder in Laravel 5.3 app.