### PR TITLE
(#27) Changed config to specific env variable

### DIFF
--- a/src/config/briteverify.php
+++ b/src/config/briteverify.php
@@ -24,6 +24,6 @@ return [
     |
     */
 
-    'pretend' => env('APP_ENV') == 'local' || env('APP_ENV') == 'testing' ? true : false,
+    'pretend' => env('BRITEVERIFY_PRETEND', false),
 
 ];


### PR DESCRIPTION
Instead of depending on APP_ENV for variable, will use BRITEVERIFY_PRETEND instead to allow more
flexibility for using/testing BriteVerify functionality.