### PR TITLE
(Closes #31) Fix the verify function

### DIFF
--- a/src/REINetwork/BriteVerify/Client.php
+++ b/src/REINetwork/BriteVerify/Client.php
@@ -65,13 +65,19 @@ class Client
      */
     public function verify($address)
     {
+        $headers = [
+            'apikey' => $this->token,
+            'address' => $address,
+        ];
+
+        $queryString = http_build_query($headers);
+
+        $endPoint = $this->endpoint . "?$queryString";
+
         $request = new Request(
             'GET',
-            $this->endpoint,
-            [
-                'apikey' => $this->token,
-                'address' => $address,
-            ]
+            $endPoint,
+            $headers
         );
 
         $response = $this->client->send($request);

--- a/tests/ClientIntegrationTest.php
+++ b/tests/ClientIntegrationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use REINetwork\BriteVerify\Client;
+
+class ClientIntegrationTest extends TestCase
+{
+    /** @var string */
+    private $token;
+
+    /** @var  Client */
+    private $client;
+
+    public function setUp()
+    {
+        $this->token = "";  // Insert the token here for testing
+        $this->client = new Client($this->token);
+    }
+
+    /**
+     * Validates that the verify function works with actual data. Fill in the fields as needed to actually test
+     * the function out. Otherwise, if the token is empty, then the test will pass by default but not run anything.
+     *
+     * @dataProvider dataProvider
+     *
+     * @param string $email
+     * @param string $expected
+     */
+    public function testVerifyWorks($email, $expected)
+    {
+        // If token is set, proceed with test. Otherwise, ignore this test
+        if (!empty($this->token)) {
+            $results = $this->client->verify($email);
+            $this->assertEquals($expected, $results->status);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider()
+    {
+        return [
+            ['kenneth@reinetworklp.com', "valid"],
+            ['kenneth@asdfasdf.com', "invalid"],
+        ];
+    }
+}


### PR DESCRIPTION
Changed it so that it uses a query string to pass in the parameters. Before, it was
sitting in the header that was passed but that wasn't working. Now, it should work
with the correctly passed parameters.